### PR TITLE
extensions/v1beta1 has been deprecated for apps/v1

### DIFF
--- a/src/metrics-server/metrics-server-deployment.yaml
+++ b/src/metrics-server/metrics-server-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-server


### PR DESCRIPTION
Update the `apiVersion` of metrics-server-deployment.yaml to the current `apiVersion`